### PR TITLE
Bump aws provider to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/minimal/versions.tf
+++ b/examples/minimal/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## Depends on PR https://github.com/cloudposse/terraform-aws-s3-bucket/pull/131

## what
* Bump s3 bucket module to use v4 provider
* Bump aws provider to v4

## why
* Team decision has been to not pin modules to major versions so better to role forward
* Many errors with v4 in cloudposse/s3-bucket module

```
│ Error: Unsupported attribute
│ 
│   on .terraform-mdev/modules/mwaa_environment.mwaa_s3_bucket/main.tf line 166, in resource "aws_s3_bucket" "default":
│  166:         for_each = local.s3_replication_rules == null ? [] : local.s3_replication_rules
│ 
│ This object does not have an attribute named "s3_replication_rules".
```

## references
* https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0
