### PR TITLE
fix: Change kms policy statement resource to NOT resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ data "aws_iam_policy_document" "this" {
       "kms:Encrypt"
     ]
     effect    = "Allow"
-    resources = ["arn:${local.partition}:kms:*:${local.account_id}:key/*"]
+    not_resources = ["arn:${local.partition}:kms:*:${local.account_id}:key/*"]
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "this" {
       "kms:GenerateDataKey*",
       "kms:Encrypt"
     ]
-    effect    = "Allow"
+    effect        = "Allow"
     not_resources = ["arn:${local.partition}:kms:*:${local.account_id}:key/*"]
     condition {
       test     = "StringLike"


### PR DESCRIPTION
## what
* Changed IAM execution role Policy KMS permission statement from a resource to a NotResource

## why
* This change complies with the suggested policy for an AWS owned key.
* Experienced that task logs were not generated in Cloudwatch and DAGs fail in Airflow with an error such as: 'Could not read remote logs from log_group: XXXXXXX'

## references
* AWS Recommended Policy for AWS owned key: https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html#mwaa-create-role-aocmk

