### PR TITLE
Fix Security Group Outputs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,16 +44,16 @@ output "webserver_url" {
 }
 
 output "security_group_id" {
-  value       = join("", module.mwaa_security_group.*.id)
+  value       = join("", compact(module.mwaa_security_group.*.id))
   description = "The ID of the created security group"
 }
 
 output "security_group_arn" {
-  value       = join("", module.mwaa_security_group.*.arn)
+  value       = join("", compact(module.mwaa_security_group.*.arn))
   description = "The ARN of the created security group"
 }
 
 output "security_group_name" {
-  value       = join("", module.mwaa_security_group.*.name)
+  value       = join("", compact(module.mwaa_security_group.*.name))
   description = "The name of the created security group"
 }


### PR DESCRIPTION
## what
- `compact()` `module.mwaa_security_group.*` outputs 

## why
- Fix edge case error:
```

│ Error: Invalid function argument
│
│   on .terraform-x/modules/mwaa_environment/outputs.tf line 52, in output "security_group_arn":
│   52:   value       = join("", module.mwaa_security_group.*.arn)
│     ├────────────────
│     │ module.mwaa_security_group is object with 4 attributes
│
│ Invalid value for "lists" parameter: element 0 is null; cannot concatenate null values.
╵
```


