### PR TITLE
added ability to add custom policies to mwaa role

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Available targets:
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Enabling or disabling the creatation of a default IAM Role for AWS MWAA | `bool` | `true` | no |
 | <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | Enabling or disabling the creatation of an S3 bucket for AWS MWAA | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Set `true` to create and configure a new security group. If false, `associated_security_group_ids` must be provided. | `bool` | `true` | no |
+| <a name="input_custom_policies"></a> [custom\_policies](#input\_custom\_policies) | If `create_iam_role` is set to `true`, list of custom policies in json format can be provided and added to role | `list(string)` | `[]` | no |
 | <a name="input_dag_processing_logs_enabled"></a> [dag\_processing\_logs\_enabled](#input\_dag\_processing\_logs\_enabled) | Enabling or disabling the collection of logs for processing DAGs | `bool` | `false` | no |
 | <a name="input_dag_processing_logs_level"></a> [dag\_processing\_logs\_level](#input\_dag\_processing\_logs\_level) | DAG processing logging level. Valid values: CRITICAL, ERROR, WARNING, INFO, DEBUG | `string` | `"INFO"` | no |
 | <a name="input_dag_s3_path"></a> [dag\_s3\_path](#input\_dag\_s3\_path) | The relative path to the DAG folder on your Amazon S3 storage bucket. | `string` | `"dags"` | no |
@@ -429,7 +430,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-mwaa&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-mwaa&utm_content=website
@@ -460,3 +461,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-mwaa
   [share_email]: mailto:?subject=terraform-aws-mwaa&body=https://github.com/cloudposse/terraform-aws-mwaa
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-mwaa?pixel&cs=github&cm=readme&an=terraform-aws-mwaa
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -50,6 +50,7 @@
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Enabling or disabling the creatation of a default IAM Role for AWS MWAA | `bool` | `true` | no |
 | <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | Enabling or disabling the creatation of an S3 bucket for AWS MWAA | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Set `true` to create and configure a new security group. If false, `associated_security_group_ids` must be provided. | `bool` | `true` | no |
+| <a name="input_custom_policies"></a> [custom\_policies](#input\_custom\_policies) | If `create_iam_role` is set to `true`, list of custom policies in json format can be provided and added to role | `list(string)` | `[]` | no |
 | <a name="input_dag_processing_logs_enabled"></a> [dag\_processing\_logs\_enabled](#input\_dag\_processing\_logs\_enabled) | Enabling or disabling the collection of logs for processing DAGs | `bool` | `false` | no |
 | <a name="input_dag_processing_logs_level"></a> [dag\_processing\_logs\_level](#input\_dag\_processing\_logs\_level) | DAG processing logging level. Valid values: CRITICAL, ERROR, WARNING, INFO, DEBUG | `string` | `"INFO"` | no |
 | <a name="input_dag_s3_path"></a> [dag\_s3\_path](#input\_dag\_s3\_path) | The relative path to the DAG folder on your Amazon S3 storage bucket. | `string` | `"dags"` | no |

--- a/main.tf
+++ b/main.tf
@@ -197,9 +197,10 @@ module "mwaa_iam_role" {
 
   use_fullname = true
 
-  policy_documents = [
-    data.aws_iam_policy_document.this.json,
-  ]
+  policy_documents = concat(
+    [data.aws_iam_policy_document.this.json], 
+    var.custom_policies
+  )
 
   policy_document_count = 1
   policy_description    = "AWS MWAA IAM policy"

--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,7 @@ module "mwaa_iam_role" {
   use_fullname = true
 
   policy_documents = concat(
-    [data.aws_iam_policy_document.this.json], 
+    [data.aws_iam_policy_document.this.json],
     var.custom_policies
   )
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "create_iam_role" {
   default     = true
 }
 
+variable "custom_policies" {
+  type        = list(string)
+  description = "If `create_iam_role` is set to `true`, list of custom policies in json format can be provided and added to role"
+  default     = []
+}
+
 variable "source_bucket_arn" {
   type        = string
   description = "If `create_s3_bucket` is `false` then set this to the Amazon Resource Name (ARN) of your Amazon S3 storage bucket."


### PR DESCRIPTION
## what
This PR adds ability to provide custom policies for MWAA IAM role, for example access to S3 bucket to store data by DAGs.
Example of passing policies to module:
```
module "my_airflow" {
  source = "cloudposse/mwaa/aws"
  ...
  create_iam_role = true # by default
  create_s3_bucket = true # by default
  custom_policies = [
    jsonencode(
      {
        "Version" : "2012-10-17",
        "Statement" : [
          {
            "Action" : [
              "s3:*",
            ],
            "Effect" : "Allow",
            "Resource" : [
              "...some-another-bucket-arn..."
            ]
          }
        ]
      }
    )
  ]
```


## why
Currently there's no way to add custom policies, only to pass your own role. But creating own role requires using own bucket, so you can't keep module to create bucket and use custom role (this role will not have access to bucket), cyclic dependencies. The solution to pass custom policies is much easier.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

