### PR TITLE
feat: add worker_replacement_strategy support for graceful updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -236,6 +236,7 @@ resource "aws_mwaa_environment" "default" {
   weekly_maintenance_window_start  = var.weekly_maintenance_window_start
   source_bucket_arn                = local.s3_bucket_arn
   execution_role_arn               = local.execution_role_arn
+  worker_replacement_strategy      = var.worker_replacement_strategy
 
   logging_configuration {
     dag_processing_logs {

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,12 @@ variable "schedulers" {
   default     = 2
 }
 
+variable "worker_replacement_strategy" {
+  type        = string
+  description = "The worker replacement strategy for environment updates. Valid values: FORCED, GRACEFUL."
+  default     = "FORCED"
+}
+
 variable "plugins_s3_object_version" {
   type        = string
   description = "The plugins.zip file version you want to use."

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.2.0"
+      version = ">= 6.11.0"
     }
   }
 }


### PR DESCRIPTION
## what

Adds new module variable `worker_replacement_strategy` for MWAA environments - can be FORCED or GRACEFUL.

AWS now allows MWAA workers to be gracefully restarted on deployments, meaning existing workers will stop accepting new work but will be allowed to finish their existing work (for up to 12 hours) before being terminated.

(Minimum AWS module version to 6.11+ to support it).

## why

- Graceful worker restarts mean jobs aren't forcefully killed mid-step during MWAA deployments.
- Default is FORCED for backward compatibility - it must be manually set to GRACEFUL

## references

- [GH issue #73](https://github.com/cloudposse/terraform-aws-mwaa/issues/73)
- [AWS announcement](https://aws.amazon.com/about-aws/whats-new/2025/05/amazon-mwaa-option-update-environments-without-interrupting-task-execution/)
- [hashicorp/aws terraform support (in v6.11+)](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mwaa_environment#worker_replacement_strategy-1)
