### PR TITLE
feat(mwaa): add `worker_replacement_strategy` variable

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -22,6 +22,8 @@ min_workers = 1
 
 max_workers = 10
 
+worker_replacement_strategy = "FORCED"
+
 webserver_access_mode = "PRIVATE_ONLY"
 
 dag_processing_logs_enabled = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -32,6 +32,7 @@ module "mwaa" {
   environment_class             = var.environment_class
   min_workers                   = var.min_workers
   max_workers                   = var.max_workers
+  worker_replacement_strategy   = var.worker_replacement_strategy
   webserver_access_mode         = var.webserver_access_mode
   dag_processing_logs_enabled   = var.dag_processing_logs_enabled
   dag_processing_logs_level     = var.dag_processing_logs_level

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -104,3 +104,15 @@ variable "min_workers" {
   description = "The minimum number of workers that you want to run in your environment."
   default     = 1
 }
+
+variable "worker_replacement_strategy" {
+  type        = string
+  description = "The worker replacement strategy to use when updating the environment. Valid values: `FORCED`, `GRACEFUL`. `FORCED` means Apache Airflow workers will be stopped and replaced without waiting for tasks to complete before an update. `GRACEFUL` means Apache Airflow workers will be able to complete running tasks for up to 12 hours during an update before being stopped and replaced."
+  default     = "FORCED"
+
+  validation {
+    condition     = contains(["FORCED", "GRACEFUL"], var.worker_replacement_strategy)
+    error_message = "Valid values are: `FORCED` or `GRACEFUL`."
+  }
+}
+

--- a/main.tf
+++ b/main.tf
@@ -223,6 +223,7 @@ resource "aws_mwaa_environment" "default" {
   kms_key                          = var.kms_key
   max_workers                      = var.max_workers
   min_workers                      = var.min_workers
+  worker_replacement_strategy      = var.worker_replacement_strategy
   min_webservers                   = var.environment_class == "mw1.micro" ? 1 : var.min_webservers
   max_webservers                   = var.environment_class == "mw1.micro" ? 1 : var.max_webservers
   schedulers                       = var.schedulers

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,17 @@ variable "min_workers" {
   default     = 1
 }
 
+variable "worker_replacement_strategy" {
+  type        = string
+  description = "The worker replacement strategy to use when updating the environment. Valid values: `FORCED`, `GRACEFUL`. `FORCED` means Apache Airflow workers will be stopped and replaced without waiting for tasks to complete before an update. `GRACEFUL` means Apache Airflow workers will be able to complete running tasks for up to 12 hours during an update before being stopped and replaced."
+  default     = null
+
+  validation {
+    condition     = var.worker_replacement_strategy == null || contains(["FORCED", "GRACEFUL"], var.worker_replacement_strategy)
+    error_message = "Valid values are: `FORCED`, `GRACEFUL`, or `null`."
+  }
+}
+
 variable "max_webservers" {
   type        = number
   description = "The maximum number of web servers that you want to run in your environment."


### PR DESCRIPTION
## what

* Added the `worker_replacement_strategy` variable to both the root and example modules, allowing users to choose between "FORCED" and "GRACEFUL" strategies for replacing Airflow workers during updates. Includes input validation to ensure only valid values are used. (`variables.tf`, `examples/complete/variables.tf`)
* Updated the `aws_mwaa_environment` resource to use the new `worker_replacement_strategy` variable, ensuring the chosen strategy is applied to the environment. (`main.tf`)
* Passed the new variable through the example module wiring, so it can be set in example deployments. (`examples/complete/main.tf`)
* Set a default value for `worker_replacement_strategy` in the example fixture file to "FORCED". (`examples/complete/fixtures.us-east-2.tfvars`)

## why

- This adds support for configuring the worker replacement strategy for Apache Airflow environments managed by this Terraform module. Users can now specify whether workers should be replaced in a "FORCED" or "GRACEFUL" manner during environment updates. The change introduces new variables, updates resource definitions, and ensures input validation for the new setting.

## references

- Closes #73 